### PR TITLE
Add Docker support and basic tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+logs
+Dockerfile
+.dockerignore
+.git
+.gitignore
+*.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 data/measurements.csv
+coverage/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18
+
+# Create app directory
+WORKDIR /app
+
+# Install app dependencies
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Bundle app source
+COPY . .
+
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dashboard
 
-Dieses Repository enthält den Quellcode für ein lokales Dashboard.
+Dieses Repository enthaelt den Quellcode fuer ein lokales Dashboard.
 
 ## Projektstruktur
 
@@ -11,3 +11,41 @@ Dieses Repository enthält den Quellcode für ein lokales Dashboard.
 
 Der Server kann mit `npm start` gestartet werden und stellt die Dateien aus dem
 Ordner `public` bereit.
+
+## Installation
+
+1. Abhaengigkeiten installieren:
+   ```bash
+   npm install
+   ```
+2. Server starten:
+   ```bash
+   npm start
+   ```
+   Der Server laeuft standardmaessig auf Port `3000`. Ueber die Umgebungsvariablen
+   `PORT` und `API_URL` koennen Port und API‑Ziel angepasst werden.
+
+## Tests
+
+Automatisierte Tests werden mit [Jest](https://jestjs.io/) ausgefuehrt:
+
+```bash
+npm test
+```
+
+## Docker
+
+Statt einer lokalen Node.js‑Installation kann das Dashboard auch in einem
+Docker‑Container betrieben werden.
+
+1. Image bauen:
+   ```bash
+   docker build -t dashboard .
+   ```
+2. Container starten:
+   ```bash
+   docker run -p 3000:3000 dashboard
+   ```
+
+Damit wird der Server innerhalb des Containers gestartet und ist anschliessend
+unter <http://localhost:3000> erreichbar.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "lint": "eslint ."
   },
   "author": "Til.D",
@@ -19,6 +19,8 @@
   "devDependencies": {
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.5",
-    "eslint-plugin-prettier": "^5.4.1"
+    "eslint-plugin-prettier": "^5.4.1",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -61,14 +61,6 @@ async function getBatteryData() {
   }
 }
 
-getBatteryData()
-  .then((data) => {
-    console.log('Batteriedaten: ', data);
-  })
-  .catch((error) => {
-    console.error(error.message);
-  });
-
 // --- Funktion zum asynchronen Speichern der Daten in eine CSV-Datei ---
 async function saveData(data) {
   let timestamp = new Date(data.Timestamp).toISOString(); // ISO-Format generieren
@@ -297,7 +289,6 @@ async function initializeData() {
     console.error('Fehler bei der Initialisierung der Daten:', error.message);
   }
 }
-initializeData();
 
 // ============================================
 //             Proxy - Aufgaben
@@ -404,4 +395,16 @@ app.use((err, req, res, next) => {
 // ============================================
 //             Server - Aufgaben
 // ============================================
-app.listen(PORT, () => console.log(`Proxy läuft auf Port ${PORT}`));
+if (require.main === module) {
+  initializeData();
+  getBatteryData()
+    .then((data) => {
+      console.log('Batteriedaten: ', data);
+    })
+    .catch((error) => {
+      console.error(error.message);
+    });
+  app.listen(PORT, () => console.log(`Proxy läuft auf Port ${PORT}`));
+}
+
+module.exports = app;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../src/server');
+
+describe('GET /slides', () => {
+  it('responds with slide data', async () => {
+    const res = await request(app).get('/slides');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('slide 1');
+  });
+});


### PR DESCRIPTION
## Summary
- add Dockerfile and dockerignore for container setup
- provide CI workflow for running tests
- document installation, tests and Docker usage in README
- export express app for testing and guard startup code
- add Jest test for `/slides` endpoint
- include jest configuration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840a30c9f1083278daeb5c0ac993604