### PR TITLE
Add cross-platform dashboard startup scripts

### DIFF
--- a/start_dashboard.bat
+++ b/start_dashboard.bat
@@ -1,0 +1,18 @@
+@echo off
+REM Startet den Node.js Server und oeffnet das Dashboard im Browser
+cd /d %~dp0
+
+REM Server in neuem Fenster starten
+start "" cmd /c "npm start"
+
+REM Kurze Wartezeit, damit der Server hochfahren kann
+timeout /t 5 > nul
+
+REM Dashboard im Vollbildmodus oeffnen (Edge oder Chrome)
+if exist "%ProgramFiles(x86)%\Microsoft\Edge\Application\msedge.exe" (
+    start "" "%ProgramFiles(x86)%\Microsoft\Edge\Application\msedge.exe" --kiosk http://localhost:3000/dashboard.html
+) else if exist "%ProgramFiles%\Google\Chrome\Application\chrome.exe" (
+    start "" "%ProgramFiles%\Google\Chrome\Application\chrome.exe" --start-fullscreen http://localhost:3000/dashboard.html
+) else (
+    start "" http://localhost:3000/dashboard.html
+)

--- a/start_dashboard_pi.sh
+++ b/start_dashboard_pi.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Startet den Node.js Server und oeffnet das Dashboard im Chromium Browser im Vollbild
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+npm start &
+SERVER_PID=$!
+
+# kurze Wartezeit, damit der Server hochfahren kann
+sleep 5
+
+# Dashboard im Vollbildmodus oeffnen
+if command -v chromium-browser > /dev/null; then
+  chromium-browser --kiosk http://localhost:3000/dashboard.html &
+elif command -v chromium > /dev/null; then
+  chromium --kiosk http://localhost:3000/dashboard.html &
+else
+  xdg-open http://localhost:3000/dashboard.html &
+fi
+
+wait $SERVER_PID


### PR DESCRIPTION
## Summary
- add Windows batch file to run server and open the dashboard in fullscreen
- add Raspberry Pi shell script to do the same

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d4b2e36c83279dae5cc8850aae7b