### PR TITLE
Fix API URLs to use relative paths

### DIFF
--- a/public/pv-anlage/anlage.html
+++ b/public/pv-anlage/anlage.html
@@ -254,7 +254,7 @@
     </div>  
     <script>
         function FetchData() {
-          const url = "http://localhost:3000/getBatteryData";
+          const url = `${window.location.origin}/getBatteryData`;
           fetch(url)
             .then(response => {
               if (!response.ok) {
@@ -569,7 +569,7 @@
 
       async function fetchTotalData() {
         try {
-          const response = await fetch('http://dashboard:3000/getTotaldata');
+          const response = await fetch(`${window.location.origin}/getTotaldata`);
           if (!response.ok) {
             throw new Error('Netzwerkantwort war nicht ok');
           }

--- a/public/pv-anlage/anlagePc.html
+++ b/public/pv-anlage/anlagePc.html
@@ -337,7 +337,7 @@
         
         
         function FetchData() {
-          const url = "http://dashboard:3000/getBatteryData";
+          const url = `${window.location.origin}/getBatteryData`;
           fetch(url, {
             method: "GET",
             headers: {
@@ -415,7 +415,7 @@
           };
           
 
-          fetch('http://dashboard:3000/save', {
+          fetch(`${window.location.origin}/save`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json'
@@ -802,7 +802,7 @@
       }
   
       async function fetchDataToday() {
-          const response = await fetch('http://dashboard:3000/measurements.csv');
+          const response = await fetch(`${window.location.origin}/measurements.csv`);
           const data = await response.text();
           return data;
       }
@@ -853,7 +853,7 @@
       }
   
       async function fetchData2024() {
-          const response = await fetch('http://dashboard:3000/statistics/statistics.csv');
+          const response = await fetch(`${window.location.origin}/statistics/statistics.csv`);
           const data = await response.text();
           return data;
       }
@@ -904,13 +904,13 @@
       }
   
       async function fetchData2023() {
-          const response = await fetch('http://dashboard:3000/statistics/2023.csv');
+          const response = await fetch(`${window.location.origin}/statistics/2023.csv`);
           const data2023 = await response.text();
           return data2023;
       }
   
       async function fetchData2022() {
-          const response = await fetch('http://dashboard:3000/statistics/2022.csv');
+          const response = await fetch(`${window.location.origin}/statistics/2022.csv`);
           const data2022 = await response.text();
           return data2022;
       }

--- a/public/statistik.html
+++ b/public/statistik.html
@@ -47,7 +47,7 @@
     <script>    
 
 async function fetchSlides() {
-  const url = "http://localhost:3000/slides";
+  const url = `${window.location.origin}/slides`;
 
   fetch(url)
     .then(response => {


### PR DESCRIPTION
## Summary
- use dynamic base URL for getBatteryData and getTotaldata
- make statistik.html fetch slides from relative `/slides`
- update PC view to fetch data with relative paths

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find eslint-plugin-prettier)*

------
https://chatgpt.com/codex/tasks/task_e_6840d737647c8327aa5ee733da129db0